### PR TITLE
Remove regression: extra Express server started during build scripts

### DIFF
--- a/src/system/server-express.js
+++ b/src/system/server-express.js
@@ -221,6 +221,4 @@ function GetTemplateValues(req) {
 }
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-Start();
-
 module.exports = { Start, CloseAppServer, OpenAppServer };


### PR DESCRIPTION
This pull request fixes both cleaning scripts from the project being broken (see issue [#11](https://github.com/theRAPTLab/meme-2023/issues/11)). It removes an incorrect call to start the express server whenever the file was imported, which resulted in either the `npm run clean` script never finishing or other various errors for `npm run clean:all`


**New Changes:**
- Removed the unconditional call to start the express server in `server-express.js`.

**Testing Instructions:**
1. Pull this branch locally and switch to it.
2. Run the cleaning scripts with `npm run clean` and `npm run clean:all`.
3. Verify that no errors are returned.
4. Verify that other scripts (`npm run dev`, `npm run start`, etc) still work as expected

**Technical Background Info:**
The express server was previously started whenever `server-express.js` was imported due to an incorrect call. This has been fixed by removing the automatic call and only starting the server when the `Start()` function is called.