### PR TITLE
DRAFT: Fix outcome & entities being displayed offscreen

### DIFF
--- a/src/app-web/views/ViewMain/ViewMain.jsx
+++ b/src/app-web/views/ViewMain/ViewMain.jsx
@@ -213,7 +213,7 @@ class ViewMain extends React.Component {
     console.log('%cUpdateDimensions Fired', cssdraw);
     this.setState({
       viewWidth: Math.min(viewWidth, innerWidth),
-      viewHeight: Math.min(viewHeight, innerHeight),
+      viewHeight: Math.max(viewHeight, innerHeight),
     });
   }
 


### PR DESCRIPTION
# Summary
This PR fixes [issue #7](https://github.com/theRAPTLab/meme-2023/issues/7) where entities and models were being displayed offscreen when created. The issue was identified in the `ViewMain.jsx` file and has been addressed by modifying the calculation of `viewHeight`.

---
## User-visible changes:

Entities and models are now correctly displayed within the screen boundaries when created.

---

## Developer-relevant changes:

The calculation of `viewHeight` in `ViewMain.jsx` has been modified.

---

## Testing Steps
1. Pull the changes from the branch dev-tv/fix-outcome-entity-displayed-offscreen.
2. Run the application.
3. Create a new entity or model.
4. Verify that the new entity or model is displayed within the screen boundaries.

---

## Technical Notes
Changes to `viewHeight` calculation:

The line `const viewHeight = this.viewRect.height - this.toolRect.height` was using `Math.min` to calculate the `viewHeight`. This was causing the height to be set offscreen when either `this.viewRect.height` or `this.toolRect.height` was 0. The calculation has been changed to use Math.max instead, ensuring that `viewHeight` is the larger of the two values.