### PR TITLE
Hide Badges

### DIFF
--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -134,10 +134,14 @@ PMCData.InitializeModel = (model, admdb) => {
   }
 
   // get essentials
-  const { resources, pmcData } = admdb;
+  const { resources, pmcData, classroomResources } = admdb;
 
   // Resources
   a_resources = resources || [];
+  // Look up current classroom's resources for filtering later
+  // so that resources that are currently hidden are not displayed
+  // especially VBadges
+  const thisClassroomResources = classroomResources.find(c => c.classroomId === ASET.selectedClassroomId);
 
   /*/
   The model data format changed in october 2019 to better separate pmcdata from model
@@ -176,8 +180,17 @@ PMCData.InitializeModel = (model, admdb) => {
             });
           break;
         case 'evidence':
+          // HACK
+          // Only add evidence if it's selected/included for this classroom.
+          // If this evidence is referring to a resource that is hidden
+          // (e.g. not in the current list of classroom resources), don't add it.
+          // This lets us hide evidence link badges if the resource
+          // has been hidden, without necessarily changing the data?
+          // See also BuildModel() for how evidence is built up
+          if (thisClassroomResources.resources.includes(obj.rsrcId)) {
           obj.comments = obj.comments || [];
           a_evidence.push(obj);
+          }
           break;
         default:
           console.error('PMCData.InitializeModel could not map unknown type', obj);


### PR DESCRIPTION
When a classroom resource is hidden:
* any evidence in the evidence library should be hidden (already works)
* any evidence badge (e.g. a entity, process, or outcome) that is linked to evidence should also be hidden (added with this PR)
* the project data should not change -- the evidence links/badges are simply hidden.  They should re-appear if you re-enable the resource.

# To Test
1. Use admin to select a classroom.
2. Include two classroom resources
3. Log in as a student and create a new project
4. Add an entity
5. Add a link for each evidence (e.g. you should have a "1a" and "2a" link)
6. Verify that your entity has 2 links to two different evidence
7. Go to the admin and hide evidence 2
8. Go back the user and exit to Home
9. Re-open the project
10. The second evidence link 2 should:
   * no longer be shown in the evidence library
   * no longer show an evidence badge
11. Go back to the admin and re-add evidence 2
12. Go back to the user and reload the project
13. The second evidence link and badge should now re-appear (though the order may have changed)


# CAVEATS
* The badges will not be updated immediately.  You have to reload the project to see the changes.
