### PR TITLE
Hotfix: Retain login form data across admin data updates

### DIFF
--- a/src/app-web/components/WLogin.jsx
+++ b/src/app-web/components/WLogin.jsx
@@ -57,9 +57,10 @@ class WLogin extends React.Component {
   componentWillUnmount() {}
 
   DoADMDataUpdate() {
+    const { loginId } = this.state;
     if (ADM.IsLoggedOut()) {
       this.setState({
-        loginId: '',
+        loginId, // keep the loginId in case another user is updating data
         loginDialogOpen: true
       });
     }


### PR DESCRIPTION
Fixes #23

Fixes bug where login form input field will reset if there are admin data updates, e.g. add new prop.

## To Test
1. On the first computer on a login screen and enter some text (without hitting Enter)
2. On second computer, login and create a new model
3. On the second computer, add a new prop/mech/outcome.
4. As soon as the prop is added, the login screen on the first computer refreshes.  The login should be retained and not cleared.