### PR TITLE
Update build system to show webpack build errors

### DIFF
--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -16,6 +16,10 @@ module.exports = env => {
 
   return merge([
     {
+      stats: {
+        errorDetails: true,
+        colors: true
+      },
       module: {
         rules: [
           {

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -29,7 +29,7 @@ module.exports = env => {
             // exclude: /node_modules/
           },
           {
-            test: /\.(jsx?|tsx?)$/,
+            test: /\.jsx?$/,
             use: {
               loader: 'babel-loader'
             },

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -49,7 +49,7 @@ module.exports = env => {
             include: [path.resolve(__dirname, 'src')]
           },
           {
-            test: /\.(eot|svg|ttf|woff|woff2)$/,
+            test: /\.(eot|ttf|woff|woff2)$/,
             type: 'asset/resource',
             generator: {
               filename: 'font/[name]__[hash:base64:5][ext]'

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -29,7 +29,7 @@ module.exports = env => {
             // exclude: /node_modules/
           },
           {
-            test: /\.jsx?$/,
+            test: /\.(jsx?|tsx?)$/,
             use: {
               loader: 'babel-loader'
             },

--- a/src/system/server-express.js
+++ b/src/system/server-express.js
@@ -81,7 +81,10 @@ function Start() {
     // otherwise, we are running as straight node out of npm scripts, or
     // a generic Electron binary was used to load us (Electron works just
     // as a node interpreter ya know!
-    console.log(PR, `COMPILING WEBSERVER w/ WEBPACK - THIS MAY TAKE SEVERAL SECONDS...`);
+    console.log(
+      PR,
+      `COMPILING WEBSERVER w/ WEBPACK - THIS MAY TAKE SEVERAL SECONDS...`
+    );
     DOCROOT = path.resolve(__dirname, '../../built/web');
 
     // RUN WEBPACK THROUGH API
@@ -110,6 +113,19 @@ function Start() {
           console.log(PR, `SERVING '${DOCROOT}'`);
           console.log(PR, `LIVE RELOAD ENABLED`);
         });
+      }
+    });
+
+    // log errors - relies on stat config in webpack.base.config
+    compiler.hooks.done.tap('ErrorLoggingPlugin', stats => {
+      const info = stats.toJson();
+
+      if (stats.hasErrors()) {
+        console.error('Errors:', info.errors);
+      }
+
+      if (stats.hasWarnings()) {
+        console.warn('Warnings:', info.warnings);
       }
     });
 
@@ -156,7 +172,10 @@ function Start() {
   // configure headers to allow cross-domain requests of media elements
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept'
+    );
     next();
   });
 


### PR DESCRIPTION
Previously, if webpack encountered an error during build, it would not show the actual source of the error, making it difficult to debug.

This PR makes the necessary changes to display these errors