### PR TITLE
DRAFT: Sideload URSYS into MEME 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,5 @@
 {
-  "presets": [
-    "@babel/preset-env",
-    "@babel/preset-react"
-  ],
+  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"],
   "plugins": [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-class-properties",

--- a/@build-ursys.sh
+++ b/@build-ursys.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# directory of this script
+DIR=$(cd "$(dirname "$0")"; pwd)
+DIR="$DIR/_ur/npm-scripts"
+echo "DIR: $DIR"
+
+# TERMINAL COLORS
+YEL=$(tput setaf 3)
+BLU=$(tput setaf 4)
+BGBLU=$(tput setab 4)$(tput setaf 7)
+BRI=$(tput bold)
+DIM=$(tput dim)
+RST=$(tput sgr0)
+
+# BUILD OPTIONS
+TSOPTS="--transpile-only" # use --no-cache to force a full rebuild tsnode (disables typecheck)
+
+# print URSYS build info from git data
+GIT_D=$(git log -1 --format=%cd --date=format:%Y/%m/%d)
+GIT_B=$(git branch --show-current)
+printf "${DIM}building URSYS Library from branch ${RST}${GIT_B}${DIM} commit date ${RST}${GIT_D}${RST}\n"
+# (1) always build library first
+npx ts-node-esm $TSOPTS $DIR/@build-core.mts 2>&1 | cat
+# (2) add additional tasks here (eventually can be command args)
+npx ts-node-esm $TSOPTS $DIR/@build-addons.mts 2>&1 | cat
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "main.js",
   "scripts": {
     "start": "node meme production",
-    "dev": "node meme dev",
+    "dev": ". @build-ursys.sh && node meme dev",
     "doc": "node meme doc",
     "electron": "node meme electron",
     "package": "node meme package",
@@ -35,6 +35,8 @@
     "@svgdotjs/svg.draggable.js": "^3.0.3",
     "@svgdotjs/svg.js": "^3.2.0",
     "@svgdotjs/svg.panzoom.js": "^2.1.2",
+    "@ursys/addons": "file:./_ur_addons",
+    "@ursys/core": "file:./_ur",
     "adm-zip": "^0.4.14",
     "ajv": "^6.10.2",
     "babel-polyfill": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@babel/polyfill": "^7.12.1",
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.23.3",
+    "@babel/preset-typescript": "^7.24.7",
     "@electron/notarize": "^2.3.0",
     "@electron/osx-sign": "^1.0.5",
     "acorn": "^8.11.3",

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -16,6 +16,10 @@ module.exports = env => {
 
   return merge([
     {
+      stats: {
+        errorDetails: true,
+        colors: true
+      },
       module: {
         rules: [
           {

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -49,7 +49,7 @@ module.exports = env => {
             include: [path.resolve(__dirname, 'src')]
           },
           {
-            test: /\.(eot|svg|ttf|woff|woff2)$/,
+            test: /\.(eot|ttf|woff|woff2)$/,
             type: 'asset/resource',
             generator: {
               filename: 'font/[name]__[hash:base64:5][ext]'

--- a/src/config/webpack.base.config.js
+++ b/src/config/webpack.base.config.js
@@ -29,7 +29,7 @@ module.exports = env => {
             // exclude: /node_modules/
           },
           {
-            test: /\.jsx?$/,
+            test: /\.(jsx?|tsx?)$/,
             use: {
               loader: 'babel-loader'
             },

--- a/src/system/server-express.js
+++ b/src/system/server-express.js
@@ -81,7 +81,10 @@ function Start() {
     // otherwise, we are running as straight node out of npm scripts, or
     // a generic Electron binary was used to load us (Electron works just
     // as a node interpreter ya know!
-    console.log(PR, `COMPILING WEBSERVER w/ WEBPACK - THIS MAY TAKE SEVERAL SECONDS...`);
+    console.log(
+      PR,
+      `COMPILING WEBSERVER w/ WEBPACK - THIS MAY TAKE SEVERAL SECONDS...`
+    );
     DOCROOT = path.resolve(__dirname, '../../built/web');
 
     // RUN WEBPACK THROUGH API
@@ -110,6 +113,19 @@ function Start() {
           console.log(PR, `SERVING '${DOCROOT}'`);
           console.log(PR, `LIVE RELOAD ENABLED`);
         });
+      }
+    });
+
+    // log errors - relies on stat config in webpack.base.config
+    compiler.hooks.done.tap('ErrorLoggingPlugin', stats => {
+      const info = stats.toJson();
+
+      if (stats.hasErrors()) {
+        console.error('Errors:', info.errors);
+      }
+
+      if (stats.hasWarnings()) {
+        console.warn('Warnings:', info.warnings);
       }
     });
 
@@ -156,7 +172,10 @@ function Start() {
   // configure headers to allow cross-domain requests of media elements
   app.use((req, res, next) => {
     res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+    res.header(
+      'Access-Control-Allow-Headers',
+      'Origin, X-Requested-With, Content-Type, Accept'
+    );
     next();
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,91 @@
+/*///////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  This tsconfig file is used by multiple systems in the URSYS build system:
+
+  .. the VSCODE typescript language server to provide Intellisense
+  .. the VSCODE eslint plugin to provide live type checking and linting
+  .. the eslint configuration to use typescript rules
+  .. the esbuild tool to transpile typescript files to bundles
+  .. the tsc typescript compiler to generate type declaration files
+  .. npm workspaces with shared typescript imports and dependencies
+  .. support for nodejs and web browser targets in the same npm workspace
+  .. support of shared platform-independent typescript code for projects
+
+  Maintaining compatibility between these systems is a challenge, as not
+  all options apply to each system. Annotations are provided to explain
+  which systems use each option.
+
+  NOTE: URSYS is using ts-node-esm as the runtime to enable pure
+  typescript execution in nodejs without transpilation.
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * /////////////////////////////////////*/
+{
+  "compilerOptions": {
+    // this sets the 'target' javascript version
+    "target": "es2022", // https://typescriptlang.org/tsconfig/#target
+
+    // 'module' sets the module format to export
+    // emit either cjs, esm output based on extension (mts, cjs, ...)
+    "module": "nodenext",
+
+    // 'moduleResolution' sets the module resolution algorithm
+    // uses package.json "exports" and extension (mts, cjs, ...)
+    "moduleResolution": "nodenext",
+
+    // 'paths' sets module import aliases for use by bundlers and compilers.
+    // Do not use in imports for library entrypoints! See details in link.
+    // https://typescriptlang.org/docs/handbook/modules/reference.html#paths
+    "paths": {
+      "~ur/common/*": ["./_ur/common/*"],
+      "~ur/server/*": ["./_ur/node-server/*"],
+      "~ur/web/*": ["./_ur_addons/*"],
+      "~ur/types/*": ["./_ur/_types/*"]
+    },
+
+    // when set, typeRoots looks ONLY at these paths for type resolution
+    "typeRoots": ["node_modules/@types", "_ur/_types"],
+
+    // generate .d.ts files (ignored by esbuild)
+    "declaration": true,
+
+    // skip library type checking (ignored by esbuild)
+    "skipLibCheck": true,
+
+    /** THE FOLLOWING ARE FOR ESBUILD COMPATBILITY **/
+
+    // files are compiled in isolation
+    "isolatedModules": true, // https://esbuild.github.io/content-types/#isolated-modules
+
+    // disable legacy cjs support in typescript, use only esm
+    "esModuleInterop": true, // https://esbuild.github.io/content-types/#es-module-interop
+
+    // can use extensions (e.g. .ts, .mts) in import statements
+    "allowImportingTsExtensions": true, // https://typescriptlang.org/tsconfig/#allowImportingTsExtensions
+
+    // required for allowImportingTsExtensions
+    "noEmit": true // https://typescriptlang.org/tsconfig/#noEmit
+
+    /// UNUSED OPTIONS ///
+
+    // 'rootDir' can be used to set explicit source directory which will
+    // mirror the directory structure in outDir. Don't need to set it unless
+    // you don't like the output directory structure.
+
+    // 'rootDirs' can be used to set multiple source directories that will
+    // be compiled to a single output directory.
+
+    // 'outDir' sets the output directory for the compiled files
+    // This is set by esbuild in the build script, so it is not needed here
+  },
+  // process all these files. per 'isolatedModules', they are all scanned individually
+  // rather than as a unified type system
+  "include": [
+    "_ur/**/*.ts",
+    "_ur/**/*.mts",
+    "_ur_addons/**/*.ts",
+    "_ur_addons/**/*.mts"
+  ],
+
+  // don't process the files in these directories
+  "exclude": ["node_modules", "_ur/node_modules", "_ur_addons/node_modules"]
+}


### PR DESCRIPTION
The new URSYS modular system is being retrofitted into older codebases. Because we have to retain compatibility with Turbo360's build system as it's being developed, ursys may have to be **sideloaded** as it is in NetCreate 2.0 ITEST.

## What is "Sideloading"?

This is our term for copying the `_ur` and `_ur_addons` directories into an existing project's root file, rather than using the **nested installation** intended in the future. 

The key differences:
- for our old projects, we are using old build systems that do not understand Typescript, and use the older CommonJS module conventions. 
- for the modern standalone version of URSYS, we are using Typescript and Node ES modules. This is fundamentally incompatible/

The `_ur` and `_ur_addons` are self-contained build systems that export CommonJS libraries that _are_ compatible with older systems like MEME. They are located in the root directories in both URSYS installation methods, but in the newer system we put apps into **subdirectories** each with their own `package.json` configurations. By comparison, older systems like MEME or NetCreate occupy the entirety of the root folder. 

## Work in Progress

This PR commits the changes needed to add a side-loaded installation of URSYS:

1. `@build-ursys.sh` script file added to meme root
2. `preset-typescript` added to the babel transpiler chain
3. `tsconfig.json` added to meme root, enabling typescript live linting and command-line typescript build
4. meme root `package.json` updates `npm run dev` to use `@build-ursys-sh`, and adds dependencies for `@ursys`
5. [tbd] `_ur` directory copied
6. [tbd] `_ur_addons` directory copied, skipping unnecessary addons
