### PR TITLE
Hotfix: Log File Splitting if IDLE_LOG_INTERVAL Exceeded

### DIFF
--- a/src/system/server-logger.js
+++ b/src/system/server-logger.js
@@ -1,36 +1,32 @@
 /* eslint-disable no-param-reassign */
 /*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
 
-  LOGGER - WIP
-  porting PLAE logger for now to get it minimally working
+  LOGGER
 
-  SUPER UGLY PORT WILL CLEAN UP LATER AVERT YOUR EYES OMG
+  - Use LOG.Write() to write to the log file directly from server
+  - Server handles 'NET:SRV_LOG_EVENT' messages to write to the log file
+  - set LOG_IDLE_INTERVAL to detect when a new log file should be created
 
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
 
-const DBG = false;
-
-/// LOAD LIBRARIES ////////////////////////////////////////////////////////////
-/// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 const PATH = require('path');
 const OS = require('os');
 const FSE = require('fs-extra');
 const Tracer = require('tracer');
-
-/// CONSTANTS /////////////////////////////////////////////////////////////////
-/// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 const PROMPTS = require('./util/prompts');
 const DATESTR = require('./util/datestring');
 const PATHS = require('./common-paths').PATHS;
 
+/// CONSTANTS & DECLARATIONS///////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = false;
 const PR = PROMPTS.Pad('LOGGER');
-
-/// MODULE-WIDE VARS //////////////////////////////////////////////////////////
-/// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
-
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const LOG_DELIMITER = '\t';
 const LOG_DIR = PATHS.Log;
 
-const LOG_DELIMITER = '\t';
+/// COLOR LOGGER (UNUSED) /////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const LOG_CONFIG = {
   format: '{{line}}  {{message}}',
   dateformat: 'HH:MM:ss.L',
@@ -39,9 +35,19 @@ const LOG_CONFIG = {
   }
 };
 const LOGGER = Tracer.colorConsole(LOG_CONFIG);
-let fs_log = null;
 
-function StartLogging() {
+/// FILE STREAMS //////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+let fs_log = null; // filesystem
+let fs_lastwrite = null; // date created
+const LOG_IDLE_INTERVAL = 1000 * 60 * 60 * 4; // 4 hours
+// const LOG_IDLE_INTERVAL = 1000 * 60; // 1 minute
+
+/// HELPER METHODS ////////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** create a new log file in the log directory and update the fs_log stream
+ *  pointe. also sets the creation date  */
+function m_StartLogging() {
   // initialize event logger
   let dir = PATH.resolve(LOG_DIR);
   try {
@@ -50,20 +56,30 @@ function StartLogging() {
     let logname = `${DATESTR.DatedFilename('log')}.txt`;
     let pathname = `${dir}/${logname}`;
     fs_log = FSE.createWriteStream(pathname);
-    LogLine(`MEME APPSERVER SESSION LOG for ${DATESTR.DateStamp()} ${DATESTR.TimeStamp()}`);
-    LogLine('---');
+    fs_lastwrite = new Date();
+    m_LogLine(
+      `MEME APPSERVER SESSION LOG for ${DATESTR.DateStamp()} ${DATESTR.TimeStamp()}`
+    );
+    m_LogLine('---');
   } catch (err) {
     if (err) throw new Error(`could not make ${dir} directory`);
   }
 }
-
-/**	LOGGING FUNCTIONS ******************************************************/
 ///	- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/	Log a standard system log message
-/*/
-function LogLine(...args) {
-  if (!fs_log) StartLogging();
-
+/**	Log a standard system log message */
+function m_LogLine(...args) {
+  // if there is no open log file, create one
+  if (!fs_log) m_StartLogging();
+  // check if the log file is older than 24 hours
+  const timeSince = new Date() - fs_lastwrite;
+  if (timeSince > LOG_IDLE_INTERVAL) {
+    // if the log file is older than LOG_IDLE_INTERVAL, create a new one
+    fs_log.write(`--- Warning: closing log file due to excess idle time!\n`);
+    fs_log.write(`--- A new log file will be created.\n`);
+    fs_log.write(`--- (did you leave the server running overnight?)\n`);
+    fs_log.end();
+    m_StartLogging();
+  }
   let out = `${DATESTR.TimeStamp()} `;
   let c = args.length;
   // arguments are delimited
@@ -75,24 +91,23 @@ function LogLine(...args) {
   }
   out += '\n';
   fs_log.write(out);
+  fs_lastwrite = new Date();
 }
 
-/// API METHODS ///////////////////////////////////////////////////////////////
-/// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
+/// EXPORTED METHODS //////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 let LOG = {};
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ API: Handle incoming log events
-/*/
+/** API: Handle incoming log events */
 LOG.PKT_LogEvent = pkt => {
   let { event, items } = pkt.Data();
   if (DBG) console.log(PR, pkt.Info(), event, ...items);
-  LogLine(pkt.Info(), event || '-', ...items);
+  m_LogLine(pkt.Info(), event || '-', ...items);
   return { OK: true };
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-/*/ API: Write to log as delimited arguments
-/*/
-LOG.Write = LogLine;
+/** API: Write to log as delimited arguments */
+LOG.Write = m_LogLine;
 
 /// EXPORT MODULE DEFINITION //////////////////////////////////////////////////
 /// = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =


### PR DESCRIPTION
This PR updates `server-logger.js` to keep track of the last time a logline was written. It address issues #117

The heuristic used:

- if the server hasn't received a Log.Write() from _any source_, then the server is **idle**
- If the **idle time counter** exceeds a threshold, then we should close the old file and write a new one before writing a log line.
- Otherwise, write the log line and reset the idle time counter

## CAVEATS 

Note that _ANY_ log write will reset the "last time written", so there is potential for long-running servers without clients to still generate log lines such as database AUTOSAVES or SNAPSHOTS which might disrupt our intention.

- The default `LOG_IDLE_INTERVAL` value is currently 4 hours, which will reset every time a log message happens. 
- Database autosave should only fire if there is a database update, so if it doesn't change there should be no autosaves.
- @benloh can confirm if 4 hours is adequate clearance for SNAPSHOT timers, which emit log messages.
- The Turbo360 version of MEME should not be affected, since they implement their own server back-end for LOGGER. Tagging @Sakelun in case I'm wrong about this.

## TESTING

First set up MEME for testing:

- in `server-logger.js`, change the `LOG_IDLE_INTERVAL` from 4 hours to something shorter (1 minute, 5 minutes)
- check the `data/logs` directory in a separate terminal window
- start up MEME on the test platform (`npm run dev`)
- note the `<name of log>` file created by MEME on startup
- `tail -f <name-of-log>` to watch the contents of the log file

Next, interact with MEME:
- browse to MEME and connect users to their projects and faff around
- wait for your shorter duration without any MEME input. If you set `LOG_IDLE_INTERVAL` to 5 minutes, wait for 6 minutes. 
- after waiting, perform an action in the MEME app. You should see this message in the terminal `tail -f` output:
```
--- Warning: closing log file due to excess idle time!
--- A new log file will be created.
--- (did you leave the server running overnight?)
```

Open another terminal window and cd to `data/logs`. You should see a **new** log file. 
- `tail -f <new-log>` to watch the contents of the new log file. You should see carry-over from the last action you entered
- the old file should no longer be receiving log

