### PR TITLE
Disable ControlBar while PropDialog and MechDialog are open

### DIFF
--- a/src/app-web/components/ClickAway.jsx
+++ b/src/app-web/components/ClickAway.jsx
@@ -1,0 +1,61 @@
+/*//////////////////////////////// ABOUT \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*\
+
+  ClickAway
+
+  TO USE
+
+    <ClickAway onClickAway={() => console.log('clicked awway!!!')}>
+      <div>Hello World</div>
+    </ClickAway>
+
+  NOTE
+
+    ClickAway can inadvertently disable clicks from other sources.  e.g.
+    * Clicks from Template Node/Edge Type color selection
+
+\*\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\ * //////////////////////////////////////*/
+
+const React = require('react');
+
+/// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+const DBG = true;
+const PR = 'ClickAway';
+
+/// REACT COMPONENT ///////////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+class ClickAway extends React.Component {
+  constructor(props) {
+    super(props);
+    this.containerRef = React.createRef();
+    this.handleClick = this.handleClick.bind(this);
+    document.addEventListener('click', this.handleClick);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleClick);
+  }
+
+  handleClick(event) {
+    console.log('click');
+    event.preventDefault();
+    event.stopPropagation();
+    const { onClickAway } = this.props;
+    if (
+      this.containerRef.current &&
+      !this.containerRef.current.contains(event.target)
+    ) {
+      if (DBG) console.log('clicked away');
+      onClickAway(event);
+    } else if (DBG) console.log('clicked children');
+  }
+
+  render() {
+    const { children } = this.props;
+    return <div ref={this.containerRef}>{children}</div>;
+  }
+}
+
+/// EXPORT REACT COMPONENT ////////////////////////////////////////////////////
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+module.exports = ClickAway;

--- a/src/app-web/components/MEPanelTools.css
+++ b/src/app-web/components/MEPanelTools.css
@@ -29,9 +29,9 @@
   font-size: var(--txt-size-sm);
   font-weight: var(--txt-weight-semibold);
 }
-.MEPanelTools .entitiesPanel button,
-.MEPanelTools .processesPanel button,
-.MEPanelTools .outcomesPanel button {
+.MEPanelTools .entitiesPanel > button,
+.MEPanelTools .processesPanel > button,
+.MEPanelTools .outcomesPanel > button {
   color: var(--clr-txt-reverse);
   margin-top: 8px;
 }
@@ -39,21 +39,21 @@
   color: var(--clr-entity);
   background-color: var(--clr-entity-bg);
 }
-.MEPanelTools .entitiesPanel button {
+.MEPanelTools .entitiesPanel > button {
   background-color: var(--clr-entity);
 }
 .MEPanelTools .processesPanel {
   color: var(--clr-mech);
   background-color: var(--clr-mech-bg);
 }
-.MEPanelTools .processesPanel button {
+.MEPanelTools .processesPanel > button {
   background-color: var(--clr-mech);
 }
 .MEPanelTools .outcomesPanel {
   color: var(--clr-outcome);
   background-color: var(--clr-outcome-bg);
 }
-.MEPanelTools .outcomesPanel button {
+.MEPanelTools .outcomesPanel > button {
   background-color: var(--clr-outcome);
 }
 
@@ -65,6 +65,10 @@
   flex-direction: column;
   row-gap: 8px;
   line-height: var(--txt-size-med);
+}
+.MEPanelTools .WDisclosure .disabled {
+  opacity: 0.5;
+  pointer-events: none;
 }
 
 .MEPanelTools .subItem {

--- a/src/app-web/components/MEPanelTools.jsx
+++ b/src/app-web/components/MEPanelTools.jsx
@@ -55,7 +55,8 @@ class MEPanelTools extends React.Component {
       selectedPropId: '',
       selectedMechId: '', // edgeObj e.g. {w,v}
       hoveredPropId: '',
-      hoveredMechId: '' // edgeObj e.g. {w,v}
+      hoveredMechId: '', // edgeObj e.g. {w,v}
+      propOrMechDialogIsOpen: false
     };
 
     UR.Subscribe('SELECTION_CHANGED', this.DoSelectionChange);
@@ -110,9 +111,13 @@ class MEPanelTools extends React.Component {
     if (selectedMechIds.length > 0) {
       selectedMechId = CoerceToEdgeObj(selectedMechIds[0]);
     }
+
+    // If prop or mech dialog is open, don't allow clicks
+    const propOrMechDialogIsOpen = DATA.VM_PropOrMechDialogIsOpen();
     this.setState({
       selectedPropId,
-      selectedMechId
+      selectedMechId,
+      propOrMechDialogIsOpen
     });
   }
 
@@ -185,7 +190,7 @@ class MEPanelTools extends React.Component {
 
   // This supports recursive calls to handle nested components.
   RenderComponentsListItem(propId, isSub = false) {
-    const { selectedPropId, hoveredPropId } = this.state;
+    const { selectedPropId, hoveredPropId, propOrMechDialogIsOpen } = this.state;
     const { theme: classes } = this.props;
     const prop = DATA.Prop(propId);
     if (prop === undefined) {
@@ -206,7 +211,8 @@ class MEPanelTools extends React.Component {
         : 'clr-item-entity';
     const cssSelected = selectedPropId === propId ? 'selected' : '';
     const cssHovered = hoveredPropId === propId ? 'hovered' : '';
-    const cssClasses = `${cssSub} ${cssClr} ${cssSelected} ${cssHovered}`;
+    const cssIsDisabled = propOrMechDialogIsOpen ? 'disabled' : '';
+    const cssClasses = `${cssSub} ${cssClr} ${cssSelected} ${cssHovered} ${cssIsDisabled}`;
 
     return (
       <div
@@ -231,8 +237,8 @@ class MEPanelTools extends React.Component {
   }
 
   RenderMechanismsList(mechIds) {
-    const { selectedMechId, hoveredMechId } = this.state;
-    const { theme: classes } = this.props;
+    const { selectedMechId, hoveredMechId, propOrMechDialogIsOpen } = this.state;
+    const { theme: classes, isDisabled } = this.props;
     let i = 0;
     return mechIds.map(mechId => {
       const mech = DATA.Mech(mechId);
@@ -251,7 +257,8 @@ class MEPanelTools extends React.Component {
           : '';
       const cssHovered =
         hoveredMechId.v === mechId.v && hoveredMechId.w === mechId.w ? 'hovered' : '';
-      const cssClasses = `item clr-item-mech ${cssSelected} ${cssHovered}`;
+      const cssIsDisabled = propOrMechDialogIsOpen || isDisabled ? 'disabled' : '';
+      const cssClasses = `item clr-item-mech ${cssSelected} ${cssHovered} ${cssIsDisabled}`;
 
       return (
         <div

--- a/src/app-web/components/WMechDialog.css
+++ b/src/app-web/components/WMechDialog.css
@@ -16,10 +16,45 @@
 }
 .WMechDialog form .dialog-row {
   display: flex;
+  align-items: center;
   column-gap: 10px;
 }
 .WMechDialog form .dialog-row.control-bar {
   display: grid;
   grid-template-columns: auto 100px 100px;
   align-items: flex-end;
+}
+
+.WMechDialog form .dialog-row .EVLinkButton {
+  max-width: 20%;
+}
+
+/* One-way/Two-way Switch */
+.WMechDialog button.switch {
+  margin: 0;
+  padding: 0;
+  border: 1px solid #0003;
+  border-radius: 10px;
+  font-size: 10px;
+  height: 20px;
+  line-height: 20px;
+}
+.WMechDialog button.switch span {
+  margin: 1px;
+  padding: 7px 10px 8px 10px;
+  pointer-events: none;
+  border-radius: 8px;
+  height: 18px;
+  line-height: 4px;
+}
+
+[role='switch'][aria-checked='false'] :first-child,
+[role='switch'][aria-checked='true'] :last-child {
+  background: var(--clr-btn-primary);
+  color: #eef;
+}
+
+[role='switch'][aria-checked='false'] :last-child,
+[role='switch'][aria-checked='true'] :first-child {
+  color: #bbd;
 }

--- a/src/app-web/components/WMechDialog.jsx
+++ b/src/app-web/components/WMechDialog.jsx
@@ -92,6 +92,7 @@ class WMechDialog extends React.Component {
   DoAdd() {
     if (DBG) console.log(PKG, 'Add Mech!');
     DATA.VM_SetSelectionLimit(2); // Allow up to 2 props to be selected.
+    DATA.VM_SetPropOrMechDialogIsOpen(true);
     this.setState(
       {
         isOpen: true,
@@ -148,6 +149,7 @@ class WMechDialog extends React.Component {
             },
             () => this.DoSelectSourceAndTarget(sourceId, targetId) // show the selected props
           );
+          DATA.VM_SetPropOrMechDialogIsOpen(true);
         } else {
           alert(
             `Sorry, someone else (${rdata.lockedBy}) is editing this ${DATAMAP.PMC_MODELTYPES.MECHANISM.label} right now.  Please try again later.`
@@ -171,6 +173,7 @@ class WMechDialog extends React.Component {
       UR.DBTryRelease('pmcData.entities', [pmcDataId, intMechId]);
     }
     DATA.VM_SetSelectionLimit(1); // Go back to allowing only one.
+    DATA.VM_SetPropOrMechDialogIsOpen(false);
     UR.Publish('MECHDIALOG_CLOSED');
   }
 

--- a/src/app-web/components/WPropDialog.jsx
+++ b/src/app-web/components/WPropDialog.jsx
@@ -61,6 +61,7 @@ class WPropDialog extends React.Component {
         description: data.description || '',
         isProperty: data.isProperty
       });
+      DATA.VM_SetPropOrMechDialogIsOpen(true);
       return;
     }
     const pmcDataId = ASET.selectedPMCDataId;
@@ -82,6 +83,7 @@ class WPropDialog extends React.Component {
           description: data.description || '',
           isProperty: data.isProperty
         });
+        DATA.VM_SetPropOrMechDialogIsOpen(true);
       } else {
         alert(
           `Sorry, someone else (${rdata.lockedBy}) is editing this ${data.propType} right now.  Please try again later.`
@@ -96,6 +98,7 @@ class WPropDialog extends React.Component {
     const pmcDataId = ASET.selectedPMCDataId;
     const intPropId = Number(this.state.propId);
     UR.DBTryRelease('pmcData.entities', [pmcDataId, intPropId]);
+    DATA.VM_SetPropOrMechDialogIsOpen(false);
     UR.Publish('PROPDIALOG_CLOSE');
   }
 

--- a/src/app-web/modules/vm-data.js
+++ b/src/app-web/modules/vm-data.js
@@ -12,6 +12,7 @@ const map_vmechs = new Map(); // our mechanism viewmodel data stored by pathid
 const selected_vprops = new Set();
 const selected_vmechs = new Set();
 const map_rollover = new Map();
+let propOrMechDialogIsOpen = false;
 
 let max_selections = 1; // Limit the number of objects that can be selected simultaneously
 
@@ -21,6 +22,12 @@ const DBG = false;
 const PKG = 'VMDATA';
 const { CoerceToPathId, CoerceToEdgeObj } = DEFAULTS;
 const VM = {};
+
+VM.VM_SetPropOrMechDialogIsOpen = bool => {
+  propOrMechDialogIsOpen = bool;
+  UR.Publish('SELECTION_CHANGED');
+};
+VM.VM_PropOrMechDialogIsOpen = () => propOrMechDialogIsOpen;
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** URSYS: DATABASE SYNC

--- a/src/app-web/modules/vm-data.js
+++ b/src/app-web/modules/vm-data.js
@@ -275,7 +275,7 @@ VM.VM_PropMouseEnter = vprop => {
 VM.VM_PropMouseExit = vprop => {
   if (vprop.posMode.isDragging) return;
   map_rollover.delete(vprop.Id());
-  vprop.HoverState(false);
+  vprop.HoverState(false, true); // publishEvent = true for vprops
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** API.UI:

--- a/src/app-web/views/ViewMain/PrintMain.css
+++ b/src/app-web/views/ViewMain/PrintMain.css
@@ -1,0 +1,3 @@
+#app-container {
+  overflow: visible; /* override ViewMEME.css */
+}

--- a/src/app-web/views/ViewMain/PrintMain.jsx
+++ b/src/app-web/views/ViewMain/PrintMain.jsx
@@ -40,6 +40,9 @@ import ASET from '../../modules/adm-settings';
 import DATAMAP from '../../../system/common-datamap';
 import { cssreact, cssdraw, cssalert } from '../../modules/console-styles';
 
+// Override ViewMEME.css
+import './PrintMain.css';
+
 /// CONSTANTS /////////////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const DBG = false;
@@ -152,11 +155,18 @@ class PrintMain extends React.Component {
     const innerHeight = window.innerHeight - this.toolRect.height;
 
     // debugging: double-refresh issue
-    console.log('%cUpdateDimensions Fired', cssdraw);
+    console.log(`%cUpdateDimensions Fired ${viewWidth} ${viewHeight}`, cssdraw);
+    // HACK: For print view, ignore window height so that the graph will show the full size
+    // REVIEW: The proper solution is to a) remove MUI, b) redo the rendering
     this.setState({
-      viewWidth: Math.min(viewWidth, innerWidth),
-      viewHeight: Math.min(viewHeight, innerHeight)
+      viewWidth: 1024,
+      viewHeight: 1024
     });
+    // Orig code:
+    // this.setState({
+    //   viewWidth: Math.min(viewWidth, innerWidth),
+    //   viewHeight: Math.min(viewHeight, innerHeight)
+    // });
   }
 
   OnCloseModel() {

--- a/src/app-web/views/ViewMain/ViewMEME.jsx
+++ b/src/app-web/views/ViewMain/ViewMEME.jsx
@@ -173,7 +173,8 @@ class ViewMEME extends React.Component {
       addEdgeTarget: '', // Add Mech Dialog
       componentIsSelected: false, // A component or component property has been selected by user.  Used for pro-centric actions.
       outcomeIsSelected: false, // A outcome or outcome property has been selected by user.  Used for pro-centric actions.
-      mechIsSelected: false // A mechanism is slected by user.  Used for mech-centric actions.
+      mechIsSelected: false, // A mechanism is slected by user.  Used for mech-centric actions.
+      suppressControlBar: false // used to hide Add/Edit buttons when dialogs are open
     };
   }
 
@@ -336,7 +337,8 @@ class ViewMEME extends React.Component {
       : DATAMAP.PMC_MODELTYPES.OUTCOME.id;
     UR.Publish('PROPDIALOG_OPEN', { isProperty: true, propType });
     this.setState({
-      addPropOpen: true
+      addPropOpen: true,
+      suppressControlBar: true
     });
   }
 
@@ -354,14 +356,18 @@ class ViewMEME extends React.Component {
         isProperty: false
       });
       this.setState({
-        addPropOpen: true
+        addPropOpen: true,
+        suppressControlBar: true
       });
     }
   }
 
   OnPropDialogClose() {
     if (DBG) console.log('close');
-    this.setState({ addPropOpen: false });
+    this.setState({
+      addPropOpen: false,
+      suppressControlBar: false
+    });
   }
 
   // User selected component/prop and clicked on "() Delete"
@@ -449,7 +455,7 @@ class ViewMEME extends React.Component {
     // Deselect any mechanisms that might be currently selected so that user can select props
     DATA.VM_DeselectAllMechs();
     this.setState({
-      suppressSelection: true // used to hide Add/Edit buttons
+      suppressControlBar: true // used to hide Add/Edit buttons
     });
     UR.Publish('MECHDIALOG:ADD');
   }
@@ -460,7 +466,7 @@ class ViewMEME extends React.Component {
     if (selectedMechIds.length > 0) {
       DATA.VM_DeselectAll(); // deselect so mech buttons disappear
       this.setState({
-        suppressSelection: true, // used to hide Add/Edit buttons
+        suppressControlBar: true, // used to hide Add/Edit buttons
         addEdgeOpen: true
       });
       let mechId = selectedMechIds[0];
@@ -480,7 +486,7 @@ class ViewMEME extends React.Component {
 
   DoMechClosed() {
     this.setState({
-      suppressSelection: false,
+      suppressControlBar: false,
       addEdgeOpen: false
     });
   }
@@ -649,7 +655,7 @@ class ViewMEME extends React.Component {
       componentIsSelected,
       outcomeIsSelected,
       mechIsSelected,
-      suppressSelection
+      suppressControlBar
     } = this.state;
 
     // we need to use the model author here, not the currently logged in student.
@@ -752,7 +758,7 @@ class ViewMEME extends React.Component {
     /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     /// Component/Mech add/edit/delete buttons that respond to selection events
     const CONTROLBAR = (
-      <div className="controlbar" hidden={suppressSelection}>
+      <div className="controlbar" hidden={suppressControlBar}>
         <button
           className="danger"
           hidden={


### PR DESCRIPTION
Fixes #120 and #125

# Problem

While a Prop or Mech Dialog is open you can still
* select another prop/mech from the left sidebar (MEPanelTools)
* select another prop/mech from the graph
This leaves your Prop/Mech Dialog in a dubious state -- are you editing the secondary select or the initial select?
This open dialog and indeterminate state was also causing problems if you navigate away from one project to another.  (See #112)

BUT, it's also important that the graph view remains zoomable/pan-able so that you can review the graph, AND you can select source/target props for Mechs.  So we can't just disable selection.

# The Fix
* Disable the left sidebar (MEPanelTools) when a Prop or Mech Dialog is open
* Disable the controlBar (Add, Delete, Edit a selected Prop or Mech) while the Prop or Mech Dialog is open.

Also a minor fix:
* Mouse exit on vprops was not triggering a HOVER_END.