### PR TITLE
Auto-open comment type when creating a new comment.  #152

### DIFF
--- a/src/system/comment-mgr/comment-db.js
+++ b/src/system/comment-mgr/comment-db.js
@@ -42,7 +42,7 @@ function GetCommentData() {
 function PromiseNewCommentID() {
   return new Promise((resolve, reject) => {
     resolve(uuidv4()); // use uuid
-  })
+  });
 }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -134,12 +134,13 @@ function DBRemoveComment(queuedActions, cb) {
   const ids = queuedActions
     .filter(item => {
       return (
-        Object.hasOwn(item, 'id')
-        && item.id !== undefined // A newly created unsaved comment will not have an id,
+        Object.hasOwn(item, 'id') && item.id !== undefined // A newly created unsaved comment will not have an id,
         // so don't bother to try remove it from the database
-      )
+      );
     })
-    .map(item => { return { id: item.id } });
+    .map(item => {
+      return { id: item.id };
+    });
   // FIXME: Need to add LOCK before DB update???
   PMC.UR_CommentsDelete(ids);
 

--- a/src/system/comment-mgr/comment-db.js
+++ b/src/system/comment-mgr/comment-db.js
@@ -79,9 +79,8 @@ function DBUnlockComment(lokiObjID, cb) {
  * @param {function} cb
  */
 function DBUpdateComment(cobj, cb) {
-  console.log('DBUpdateComment', cobj)
-  const comment = { // TComment
-    // id: xxxx // don't inject `id` here yet!  Rely on pmc-objects to auto-add an id
+  const comment = {
+    id: cobj.id, // an existing pmcData object will have an id, so use that, otherwise a new comment object will be created
     collection_ref: cobj.collection_ref,
     comment_id: cobj.comment_id,
     comment_id_parent: cobj.comment_id_parent,

--- a/src/system/comment-mgr/view/URComment.jsx
+++ b/src/system/comment-mgr/view/URComment.jsx
@@ -102,6 +102,27 @@ function URComment({ cref, cid, uid }) {
     };
   }, [state.uIsBeingEdited]); // run when uIsBeingEdited changes
 
+  /** Component Effect - open TypeSelector when a NEW comment is created */
+  useEffect(() => {
+    if (state.uViewMode === CMTMGR.VIEWMODE.EDIT) {
+      // Check if it's a new comment (no text yet)
+      const isNew = state.commenter_text.every(t => t === '' || t === undefined);
+      if (isNew) {
+        const element = document.getElementById(`typeselector-${cid}`);
+        if (element) {
+          element.focus();
+          if (typeof element.showPicker === 'function') {
+            try {
+              element.showPicker();
+            } catch (e) {
+              console.warn(`${PR}: TypeSelector showPicker failed`, e);
+            }
+          }
+        }
+      }
+    }
+  }, [state.uViewMode]);
+
   /// COMPONENT HELPER METHODS ////////////////////////////////////////////////
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** Declare helper method to load viewdata from comment manager into the
@@ -363,7 +384,11 @@ function URComment({ cref, cid, uid }) {
     </button>
   );
   const TypeSelector = (
-    <select value={selected_comment_type} onChange={evt_TypeSelector}>
+    <select
+      id={`typeselector-${cid}`}
+      value={selected_comment_type}
+      onChange={evt_TypeSelector}
+    >
       {[...commentTypes.entries()].map(type => (
         <option key={type[0]} value={type[0]}>
           {type[1].label}

--- a/src/system/comment-mgr/view/URCommentPrompt.jsx
+++ b/src/system/comment-mgr/view/URCommentPrompt.jsx
@@ -81,30 +81,37 @@ function URCommentPrompt({
 
   useEffect(() => {
     if (viewMode === CMTMGR.VIEWMODE.EDIT) {
-      // find the first empty `text` prompt or the first `dropdown`
-      let foundIndex = -1;
-      const prompts = commentTypes.get(commentType).prompts;
-      prompts.find((prompt, promptIndex) => {
-        const isText = prompt.format === 'text';
-        const isDropdown = prompt.format === 'dropdown';
-        if ((isText && !commenterText[promptIndex]) || isDropdown) {
-          foundIndex = promptIndex;
+      const promptList = commentTypes.get(commentType).prompts;
+      // find the first empty prompt
+      let focusIndex = -1;
+      promptList.find((prompt, promptIndex) => {
+        if (u_IsEmpty(commenterText[promptIndex])) {
+          focusIndex = promptIndex;
           return true;
         }
       });
+
+      // if everything is filled, focus the first prompt
+      if (focusIndex === -1) focusIndex = 0;
+
       // set focus to the found element
-      const element = document.getElementById(u_PromptElementId(cref, foundIndex));
+      const element = document.getElementById(u_PromptElementId(cref, focusIndex));
       if (element) {
         element.focus();
-        // if it's a select element, try to trigger the picker
-        if (
-          element.tagName === 'SELECT' &&
-          typeof element.showPicker === 'function'
-        ) {
-          try {
-            element.showPicker();
-          } catch (e) {
-            console.warn(`${PR}: showPicker() failed`, e);
+        // if it's an empty select element, set default and try to trigger picker
+        if (element.tagName === 'SELECT' && u_IsEmpty(commenterText[focusIndex])) {
+          const prompt = promptList[focusIndex];
+          if (prompt.options && prompt.options.length > 0) {
+            // trigger onChange to set the default value in parent state
+            onChange(focusIndex, { target: { value: prompt.options[0] } });
+            // try to show picker
+            if (typeof element.showPicker === 'function') {
+              try {
+                element.showPicker();
+              } catch (e) {
+                console.warn(`${PR}: showPicker() failed`, e);
+              }
+            }
           }
         }
       }
@@ -202,23 +209,23 @@ function URCommentPrompt({
             />
           );
           break;
-        case 'dropdown':
-          if (!prompt.options.includes(commenterText[promptIndex])) {
+        case 'dropdown': {
+          let selectedValue = commenterText[promptIndex];
+          if (!prompt.options.includes(selectedValue)) {
             // currently selected value does not match an item in the dropdown
-            // fall back to the first item in the dropdown
-            if (prompt.options.length > 0)
-              commenterText[promptIndex] = prompt.options[0];
+            // fall back to the first item for display only (don't mutate props!)
+            if (prompt.options.length > 0) selectedValue = prompt.options[0];
             else {
               console.warn(
-                `Dropdown for ${commentType} has no options!  Check definition!`
+                `Dropdown for ${commentType} has no options! Check definition!`
               );
-              commenterText[promptIndex] = ''; // fall back to an empty string
+              selectedValue = '';
             }
           }
           inputJSX = (
             <select
               id={u_PromptElementId(cref, promptIndex)}
-              value={commenterText[promptIndex] || ''}
+              value={selectedValue || ''}
               onChange={event => onChange(promptIndex, event)}
             >
               {prompt.options.map((option, index) => (
@@ -229,6 +236,7 @@ function URCommentPrompt({
             </select>
           );
           break;
+        }
         case 'checkbox': {
           // converts commment text into ["Apple", "Banana"]
           const selectedCheckboxes = u_SplitCheckboxCommentText(

--- a/src/system/comment-mgr/view/URCommentPrompt.jsx
+++ b/src/system/comment-mgr/view/URCommentPrompt.jsx
@@ -79,22 +79,35 @@ function URCommentPrompt({
 }) {
   const commentTypes = CMTMGR.GetCommentTypes();
 
-  /** Component Effect - set the focus to the first empty field on
-   *  entering edit mode, or selecting a new comment type
-   */
   useEffect(() => {
     if (viewMode === CMTMGR.VIEWMODE.EDIT) {
-      // find the first empty `text` prompt
+      // find the first empty `text` prompt or the first `dropdown`
       let foundIndex = -1;
-      commentTypes.get(commentType).prompts.find((prompt, promptIndex) => {
-        if (prompt.format === 'text' && !commenterText[promptIndex]) {
+      const prompts = commentTypes.get(commentType).prompts;
+      prompts.find((prompt, promptIndex) => {
+        const isText = prompt.format === 'text';
+        const isDropdown = prompt.format === 'dropdown';
+        if ((isText && !commenterText[promptIndex]) || isDropdown) {
           foundIndex = promptIndex;
           return true;
         }
       });
-      // set focus to the found empty 'text' prompt
-      const foundTextArea = document.getElementById(u_TextareaId(cref, foundIndex));
-      if (foundTextArea) foundTextArea.focus();
+      // set focus to the found element
+      const element = document.getElementById(u_PromptElementId(cref, foundIndex));
+      if (element) {
+        element.focus();
+        // if it's a select element, try to trigger the picker
+        if (
+          element.tagName === 'SELECT' &&
+          typeof element.showPicker === 'function'
+        ) {
+          try {
+            element.showPicker();
+          } catch (e) {
+            console.warn(`${PR}: showPicker() failed`, e);
+          }
+        }
+      }
     }
   }, [viewMode, commentType]);
 
@@ -113,7 +126,7 @@ function URCommentPrompt({
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   /** Converts `index` into "prompt-<index>" for use in HTML id attributes */
-  function u_TextareaId(cref, index) {
+  function u_PromptElementId(cref, index) {
     return `prompt-${cref}-${index}`;
   }
   /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -182,7 +195,7 @@ function URCommentPrompt({
         case 'text':
           inputJSX = (
             <textarea
-              id={u_TextareaId(cref, promptIndex)}
+              id={u_PromptElementId(cref, promptIndex)}
               autoFocus
               onChange={event => onChange(promptIndex, event)}
               value={commenterText[promptIndex] || ''}
@@ -204,6 +217,7 @@ function URCommentPrompt({
           }
           inputJSX = (
             <select
+              id={u_PromptElementId(cref, promptIndex)}
               value={commenterText[promptIndex] || ''}
               onChange={event => onChange(promptIndex, event)}
             >


### PR DESCRIPTION
Two features:
1. When creating a new comment, the comment type menu is auto-opened.
2. When selecting a comment type that has a dropdown, the dropdown menu is auto-opened.

Addresses #152  


Bug fix:
- Comment counts should no longer increment whenever you edit an existing comment.
   `comment-db` was relying on pmcData to generate a new id when a comment is created.  But for an existing comment, the id was not being passed.  The result is a new comment object was created.  This fix should now correctly use the existing comment id.  Fixes  #131