### PR TITLE
DRAFT: Fix circular parent references

### DIFF
--- a/src/app-web/components/MEPanelTools.jsx
+++ b/src/app-web/components/MEPanelTools.jsx
@@ -71,6 +71,16 @@ class MEPanelTools extends React.Component {
 
   componentDidMount() {}
 
+  componentDidUpdate() {
+    // update theme URL state when unit changes
+    const unitId = ASET.selectedUnitId;
+    const themeUrl = unitId ? `/units/${unitId}/resources/theme.png` : '';
+    if (themeUrl !== this.state.themeUrl) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ themeUrl, themeLoaded: false });
+    }
+  }
+
   componentWillUnmount() {
     UR.Unsubscribe('SELECTION_CHANGED', this.DoSelectionChange);
     UR.Unsubscribe('PROP_HOVER_START', this.DoPropHoverStart);
@@ -319,12 +329,8 @@ class MEPanelTools extends React.Component {
     const isViewOnly = ADM.IsViewOnly();
 
     const unitId = ASET.selectedUnitId;
-    const themeUrl = unitId ? `/units/${unitId}/resources/theme.png` : '';
-
-    // If unit changed, reset themeLoaded
-    if (themeUrl !== this.state.themeUrl) {
-      this.setState({ themeUrl, themeLoaded: false });
-    }
+    const themeUrl =
+      this.state.themeUrl || (unitId ? `/units/${unitId}/resources/theme.png` : '');
 
     const backgroundUrl =
       this.state.themeLoaded && unitId ? themeUrl : '/static/background_science.png';

--- a/src/app-web/modules/adm-data.js
+++ b/src/app-web/modules/adm-data.js
@@ -784,7 +784,8 @@ ADMData.Logout = () => {
         urs.SESSION_Key = '';
         SESSION.Clear();
         ASET.selectedStudentId = '';
-        ADMData.SelectClassroom('');
+        ASET.selectedModelId = ''; // clear model so DoDataUpdate skips GetRatings
+        ADMData.SelectClassroom(''); // clears selectedUnitId
         UR.Publish('ADM_DATA_UPDATED');
         return rdata;
       }

--- a/src/app-web/modules/adm-data.js
+++ b/src/app-web/modules/adm-data.js
@@ -1801,14 +1801,17 @@ ADMData.GetUnitLabel = (unitId = ASET.selectedUnitId) => {
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ADMData.GetResources = (unitId = ASET.selectedUnitId) => {
+  if (!unitId || !ADMUnits.HasUnit(unitId)) return [];
   return ADMUnits.GetResources(unitId);
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ADMData.GetRatings = (unitId = ASET.selectedUnitId) => {
+  if (!unitId || !ADMUnits.HasUnit(unitId)) return [];
   return ADMUnits.GetRatings(unitId);
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ADMData.GetCommentTypes = (unitId = ASET.selectedUnitId) => {
+  if (!unitId || !ADMUnits.HasUnit(unitId)) return [];
   return ADMUnits.GetCommentTypes(unitId);
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/src/app-web/modules/class-vbadge.js
+++ b/src/app-web/modules/class-vbadge.js
@@ -261,14 +261,8 @@ class VBadge {
       baseY = y + yOffset + m_pad * 2;
     }
 
-    const badgeOffsetX = 4;
-    const badgeOffsetY = 4; // was -7
-
     // first reset positions
-    this.gStickyButtons.transform({
-      translateX: badgeOffsetX,
-      translateY: badgeOffsetY
-    });
+    this.gStickyButtons.move(0, -7);
 
     // draw evidence link badges
     // -- Clear the group in case objects have changed
@@ -282,17 +276,11 @@ class VBadge {
       evlinks.forEach((evlink, i) => {
         const badge = VBadge.SVGEvLink(evlink, vparent);
         this.oldRating = evlink.rating;
-        badge.transform({
-          translateX: badgeOffsetX + i * evlinkBadgeXOffset,
-          translateY: badgeOffsetY
-        });
+        badge.move(i * evlinkBadgeXOffset, -7);
         this.gEvLinkBadges.add(badge);
       });
       // -- Move evlink badges to the right of stickynote button
-      this.gEvLinkBadges.transform({
-        translateX: badgeOffsetX + badgeItemRadius + m_pad,
-        translateY: badgeOffsetY
-      });
+      this.gEvLinkBadges.move(badgeItemRadius + m_pad, -7);
     }
 
     // set initial position of sticky note buttons and evlink badges
@@ -301,16 +289,13 @@ class VBadge {
       : 0;
     if (this.isVMech) {
       // VMech is left-justified
-      this.gBadges.transform({
-        translateX: baseX + badgeItemRadius,
-        translateY: baseY
-      });
+      this.gBadges.move(baseX + badgeItemRadius, baseY);
     } else {
       // VProp is right-justified
-      this.gBadges.transform({
-        translateX: baseX - evlinkBadgesOffsetX - badgeItemRadius - m_pad,
-        translateY: baseY + 4
-      });
+      this.gBadges.move(
+        baseX - evlinkBadgesOffsetX - badgeItemRadius - m_pad,
+        baseY + 4
+      );
     }
 
     this.baseRedrawNeeded = false;

--- a/src/app-web/modules/class-vbadge.js
+++ b/src/app-web/modules/class-vbadge.js
@@ -261,8 +261,14 @@ class VBadge {
       baseY = y + yOffset + m_pad * 2;
     }
 
+    const badgeOffsetX = 4;
+    const badgeOffsetY = 4; // was -7
+
     // first reset positions
-    this.gStickyButtons.move(0, -7);
+    this.gStickyButtons.transform({
+      translateX: badgeOffsetX,
+      translateY: badgeOffsetY
+    });
 
     // draw evidence link badges
     // -- Clear the group in case objects have changed
@@ -276,11 +282,17 @@ class VBadge {
       evlinks.forEach((evlink, i) => {
         const badge = VBadge.SVGEvLink(evlink, vparent);
         this.oldRating = evlink.rating;
-        badge.move(i * evlinkBadgeXOffset, -7);
+        badge.transform({
+          translateX: badgeOffsetX + i * evlinkBadgeXOffset,
+          translateY: badgeOffsetY
+        });
         this.gEvLinkBadges.add(badge);
       });
       // -- Move evlink badges to the right of stickynote button
-      this.gEvLinkBadges.move(badgeItemRadius + m_pad, -7);
+      this.gEvLinkBadges.transform({
+        translateX: badgeOffsetX + badgeItemRadius + m_pad,
+        translateY: badgeOffsetY
+      });
     }
 
     // set initial position of sticky note buttons and evlink badges
@@ -289,10 +301,16 @@ class VBadge {
       : 0;
     if (this.isVMech) {
       // VMech is left-justified
-      this.gBadges.move(baseX + badgeItemRadius, baseY);
+      this.gBadges.transform({
+        translateX: baseX + badgeItemRadius,
+        translateY: baseY
+      });
     } else {
       // VProp is right-justified
-      this.gBadges.move(baseX - evlinkBadgesOffsetX - badgeItemRadius - m_pad, baseY + 4);
+      this.gBadges.transform({
+        translateX: baseX - evlinkBadgesOffsetX - badgeItemRadius - m_pad,
+        translateY: baseY + 4
+      });
     }
 
     this.baseRedrawNeeded = false;

--- a/src/app-web/modules/class-vbadge.js
+++ b/src/app-web/modules/class-vbadge.js
@@ -58,11 +58,10 @@ class VBadge {
     this.cref = '';
     this.hover = false;
     if (this.isVMech)
-      this.cref = CREF_PREFIX.PROCESS + vparent.data.id;  // CMTMGR.GetCREF('PROCESS', id);
+      this.cref = CREF_PREFIX.PROCESS + vparent.data.id; // CMTMGR.GetCREF('PROCESS', id);
     else if (vparent.isOutcome)
-      this.cref = CREF_PREFIX.OUTCOME + vparent.id;  // CMTMGR.GetCREF('OUTCOME', id);
-    else
-      this.cref = CREF_PREFIX.ENTITY + vparent.id;  // CMTMGR.GetCREF('ENTITY', id);
+      this.cref = CREF_PREFIX.OUTCOME + vparent.id; // CMTMGR.GetCREF('OUTCOME', id);
+    else this.cref = CREF_PREFIX.ENTITY + vparent.id; // CMTMGR.GetCREF('ENTITY', id);
 
     // Bind Methods
     this.Refresh = this.Refresh.bind(this);
@@ -78,16 +77,21 @@ class VBadge {
      *           +-- gEvLinkBadges (group)
      */
     this.gBadges = vparent.GetVBadgeParent().group().attr('class', 'gBadges');
-    this.gStickyButtons = VBadge.SVGStickyButton(this.gBadges, this.cref, this.isVMech);
+    this.gStickyButtons = VBadge.SVGStickyButton(
+      this.gBadges,
+      this.cref,
+      this.isVMech
+    );
     this.gEvLinkBadges = this.gBadges.group().attr('class', 'gEvLinkBadges');
 
-    this.gBadges.click(e => { this.OnClick(e); });
+    this.gBadges.click(e => {
+      this.OnClick(e);
+    });
 
     STATE.OnStateChange('COMMENTCOLLECTION', () => this.Refresh(vparent), UDATAOwner);
 
     this.Update(vparent);
     this.DrawBase(vparent);
-
   }
 
   /**
@@ -131,7 +135,7 @@ class VBadge {
       // An Evidence Link Badge got the click
       // Figure out which badge
       this.gEvLinkBadges.children().forEach(gBadge => {
-        console.log('checking', offsetX, svgPt.x, offsetY, svgPt.y, gBadge)
+        console.log('checking', offsetX, svgPt.x, offsetY, svgPt.y, gBadge);
         if (gBadge.inside(svgPt.x, svgPt.y)) {
           gBadge.fire('click', { event: mouseEvent });
         }
@@ -182,8 +186,10 @@ class VBadge {
     }
 
     // if the number of links have changed or been removed, then we need to redraw
-    if (oldEvlinks && updatedEvlinks && (oldEvlinks.length !== updatedEvlinks.length) ||
-      (oldEvlinks && !updatedEvlinks)) {
+    if (
+      (oldEvlinks && updatedEvlinks && oldEvlinks.length !== updatedEvlinks.length) ||
+      (oldEvlinks && !updatedEvlinks)
+    ) {
       redrawNeeded = true;
     }
 
@@ -278,7 +284,9 @@ class VBadge {
     }
 
     // set initial position of sticky note buttons and evlink badges
-    const evlinkBadgesOffsetX = this.evlinks ? this.evlinks.length * evlinkBadgeXOffset : 0;
+    const evlinkBadgesOffsetX = this.evlinks
+      ? this.evlinks.length * evlinkBadgeXOffset
+      : 0;
     if (this.isVMech) {
       // VMech is left-justified
       this.gBadges.move(baseX + badgeItemRadius, baseY);
@@ -318,14 +326,19 @@ class VBadge {
     const commentThreadIsOpen = uistate && uistate.isOpen;
 
     // update count on draw b/c number of comments might change
-    if (Array.isArray(comments)) this.commentCount = comments.filter(c => !c.comment_isMarkedDeleted).length;
+    if (Array.isArray(comments))
+      this.commentCount = comments.filter(c => !c.comment_isMarkedDeleted).length;
 
-    this.gStickyButtons.gLabel
-      .text(this.commentCount) // BUG: If text is empty, dragging seeems to lead to a race condition
+    this.gStickyButtons.gLabel.text(this.commentCount); // BUG: If text is empty, dragging seeems to lead to a race condition
 
     // update sticky button icons and comment count label
     // this replicates what URCommentBtn usually handles
-    if (!hasComments && !this.hover && !commentThreadIsOpen && !vparent.visualState.IsSelected()) {
+    if (
+      !hasComments &&
+      !this.hover &&
+      !commentThreadIsOpen &&
+      !vparent.visualState.IsSelected()
+    ) {
       // no sticky buttons
       this.gStickyButtons.attr({ visibility: 'hidden' });
     } else {
@@ -346,7 +359,10 @@ class VBadge {
           this.gStickyButtons.gIcon.attr('class', 'svgcmt-readSelected');
           this.gStickyButtons.gLabel.font({ fill: '#fff' });
         } else {
-          this.gStickyButtons.gIcon.attr('class', this.isVMech ? 'svgcmt-read-outlined' : 'svgcmt-read');
+          this.gStickyButtons.gIcon.attr(
+            'class',
+            this.isVMech ? 'svgcmt-read-outlined' : 'svgcmt-read'
+          );
           this.gStickyButtons.gLabel.font({ fill: COLOR.COMMENT_READ });
         }
       }
@@ -408,7 +424,10 @@ VBadge.SVGEvLink = (evlink, vparent) => {
 
   // create vbadge sub elements
   const gEvLink = root.group().attr({ id: 'gEvLink' }).click(onClick);
-  gEvLink.gRect = gEvLink.rect(badgeItemRadius * 1.75, badgeItemRadius).radius(badgeItemRadius / 2).fill('#4db6ac');
+  gEvLink.gRect = gEvLink
+    .rect(badgeItemRadius * 1.75, badgeItemRadius)
+    .radius(badgeItemRadius / 2)
+    .fill('#4db6ac');
   gEvLink.gRect.attr({ cursor: 'pointer' });
 
   gEvLink.gLabel = gEvLink
@@ -417,8 +436,10 @@ VBadge.SVGEvLink = (evlink, vparent) => {
     .dmove(badgeItemRadius / 2, badgeItemRadius / 2 + 4)
     .attr({ cursor: 'pointer' });
 
-  gEvLink.gRating = new VBadge.SVGRating(evlink, gEvLink)
-    .dmove(badgeItemRadius * 0.9, 4.5);
+  gEvLink.gRating = new VBadge.SVGRating(evlink, gEvLink).dmove(
+    badgeItemRadius * 0.9,
+    4.5
+  );
   return gEvLink;
 };
 
@@ -434,9 +455,7 @@ VBadge.SVGRating = (evlink, gEvLink) => {
     .attr({ id: 'gRatings' })
     .move(badgeItemRadius * 0.9, 4.5);
   gRatings.group().circle(18).fill('#fff');
-  gRatings.group()
-    .add(RATINGS.getSVGIcon(rating))
-    .move(1, 1);
+  gRatings.group().add(RATINGS.getSVGIcon(rating)).move(1, 1);
   return gRatings;
 };
 
@@ -461,13 +480,16 @@ VBadge.SVGStickyButton = (gbadges, cref) => {
   // create vbadge sub elements
   // 1. main gStickyButtons group
   let gStickyButton = gbadges
-    .group().addClass('gStickyNoteBtn')
+    .group()
+    .addClass('gStickyNoteBtn')
     .attr({ cursor: 'pointer' })
     .click(onClick);
   // Using the svg defs requires using `clone`
-  gStickyButton.gIcon = gStickyButton.group()
+  gStickyButton.gIcon = gStickyButton
+    .group()
     .attr('class', 'svgcmt-read')
-    .add(SVGDEFS.get('comment').clone()).scale(1.6);
+    .add(SVGDEFS.get('comment').clone())
+    .scale(1.6);
 
   // 3. comment count label group
   gStickyButton.gLabel = gStickyButton

--- a/src/app-web/modules/class-vmech.js
+++ b/src/app-web/modules/class-vmech.js
@@ -313,7 +313,7 @@ class VMech {
         this.UpdateArrowStates();
 
         // VBadge hack position of horizText
-        this.pathLabelGroup.show();
+        this.pathLabelGroup.opacity(1);
         this.pathLabelGroup.x(this.pathLabel.x() - this.pathLabelBox.width() / 2); // center it on the path
         this.pathLabelGroup.y(this.pathLabel.y());
 
@@ -322,7 +322,7 @@ class VMech {
       // no srcPt or tgtPt, so hide path if it exists
       if (this.path) this.path.hide();
       // also hide the pathlabelGroup
-      this.pathLabelGroup.hide();
+      this.pathLabelGroup.opacity(0);
     }
   }
 

--- a/src/app-web/modules/class-vmech.js
+++ b/src/app-web/modules/class-vmech.js
@@ -1,6 +1,13 @@
 import ADM from './data';
 import DATA from './data';
-import { cssinfo, cssdraw, csstab, csstab2, cssblue, cssdata } from './console-styles';
+import {
+  cssinfo,
+  cssdraw,
+  csstab,
+  csstab2,
+  cssblue,
+  cssdata
+} from './console-styles';
 import UR from '../../system/ursys';
 import DEFAULTS from './defaults';
 import { VisualState } from './classes-visual';
@@ -102,10 +109,7 @@ class VMech {
     this.horizText = this.pathLabelGroup.text(add => {
       add.tspan(this.data.name);
     });
-    this.horizText
-      .fill(COL_MECH_LABEL)
-      .move(5, 3)
-      .attr({ cursor: 'pointer' }); // offset in pathLabelBox for padding
+    this.horizText.fill(COL_MECH_LABEL).move(5, 3).attr({ cursor: 'pointer' }); // offset in pathLabelBox for padding
 
     // Add VBadge group -- this needs to be added here for layering purposes
     this.vBadge = VBadge.New(this);
@@ -116,7 +120,9 @@ class VMech {
     // .attr('dy', -6) // Original offset to move text off the pathline
     // These initial 'pathLabel' and 'textpath' settings are overriden by Update, below.
     this.pathLabel.attr('text-anchor', 'end');
-    this.textpath = this.pathLabel.path(this.path).attr('startOffset', this.path.length() - m_blen);
+    this.textpath = this.pathLabel
+      .path(this.path)
+      .attr('startOffset', this.path.length() - m_blen);
 
     // shared modes
     this.visualState = new VisualState(this.id);
@@ -204,11 +210,13 @@ class VMech {
     if (visible) {
       this.visualState.Select('hover');
       this.vBadge.hover = true;
-      if (publishEvent) UR.Publish('MECH_HOVER_START', { mechId: CoerceToEdgeObj(this.id) });
+      if (publishEvent)
+        UR.Publish('MECH_HOVER_START', { mechId: CoerceToEdgeObj(this.id) });
     } else {
       this.visualState.Deselect('hover');
       this.vBadge.hover = false;
-      if (publishEvent) UR.Publish('MECH_HOVER_END', { mechId: CoerceToEdgeObj(this.id) });
+      if (publishEvent)
+        UR.Publish('MECH_HOVER_END', { mechId: CoerceToEdgeObj(this.id) });
     }
     this.Draw();
   }
@@ -272,7 +280,9 @@ class VMech {
             this.path.marker('start', SVGDEFS.get('arrowStartHead'));
             this.path.marker('end', SVGDEFS.get('arrowEndHead'));
           } else {
-            this.path.marker('end', SVGDEFS.get('arrowEndHead')).attr('marker-start', '');
+            this.path
+              .marker('end', SVGDEFS.get('arrowEndHead'))
+              .attr('marker-start', '');
           }
           this.path.plot(m_MakeQuadraticDrawingString(srcPt, tgtPt));
           // text-anchor is like justification setting the alignment
@@ -287,7 +297,9 @@ class VMech {
             this.path.marker('start', SVGDEFS.get('arrowStartHead'));
             this.path.marker('end', SVGDEFS.get('arrowEndHead'));
           } else {
-            this.path.marker('start', SVGDEFS.get('arrowStartHead')).attr('marker-end', '');
+            this.path
+              .marker('start', SVGDEFS.get('arrowStartHead'))
+              .attr('marker-end', '');
           }
           this.path.plot(m_MakeQuadraticDrawingString(tgtPt, srcPt));
           this.pathLabel.attr('text-anchor', 'middle'); // originally was 'start'
@@ -341,7 +353,8 @@ class VMech {
     } else {
       if (this.path.reference('marker-start'))
         this.path.marker('start', SVGDEFS.get('arrowStartHead'));
-      if (this.path.reference('marker-end')) this.path.marker('end', SVGDEFS.get('arrowEndHead'));
+      if (this.path.reference('marker-end'))
+        this.path.marker('end', SVGDEFS.get('arrowEndHead'));
     }
   }
 
@@ -390,7 +403,8 @@ class VMech {
  */
 VMech.New = (pathId, svgRoot) => {
   if (DATA.VM_VMechExists(pathId)) throw Error(`${pathId} is already allocated`);
-  if (svgRoot.constructor.name !== 'Svg') throw Error(`arg2 must be SVGJS draw instance`);
+  if (svgRoot.constructor.name !== 'Svg')
+    throw Error(`arg2 must be SVGJS draw instance`);
   const vmech = new VMech(pathId, svgRoot);
   if (DBG) console.log('created vmech', vmech.id);
   DATA.VM_VMechSet(vmech, pathId);

--- a/src/app-web/modules/class-vprop-dragdrop.js
+++ b/src/app-web/modules/class-vprop-dragdrop.js
@@ -24,6 +24,13 @@ import UTILS from './utils';
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 const DBG = false;
 
+/**
+ * Module-level lock: tracks which vprop initiated the current drag.
+ * SVG.js fires dragend on ALL draggable descendants when a parent is dragged,
+ * so we only allow the actual drag initiator to process the drop.
+ */
+let activeDragId = null;
+
 /// PRIVATE HELPERS ///////////////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /**
@@ -135,6 +142,10 @@ const AddDragDropHandlers = vprop => {
   vprop.gRoot.on('dragstart.propmove', event => {
     event.stopPropagation();
     if (DBG) console.log('dragstart');
+    // Only claim the drag if no other vprop has already started one.
+    // This prevents child vprops from stealing the drag when a parent is moved.
+    if (activeDragId !== null) return;
+    activeDragId = vprop.Id();
     vprop.gRoot.attr('pointer-events', 'none');
     // REVIEW: mouse leave should not be necessary during drag?
     // DATA.VM_PropMouseExit(vprop);
@@ -161,6 +172,15 @@ const AddDragDropHandlers = vprop => {
     event.detail.event.stopPropagation();
 
     if (DBG) console.log('dragend');
+
+    // Only the vprop that initiated the drag should process the drop.
+    if (activeDragId !== vprop.Id()) {
+      if (DBG)
+        console.log(`dragend ignored for ${vprop.Id()} (active: ${activeDragId})`);
+      return;
+    }
+    activeDragId = null;
+
     vprop.gRoot.attr('pointer-events', 'all');
     SaveEventCoordsToBox(event, vprop._extend.dragdrop.endPt);
     if (vprop.DragEnd) vprop.DragEnd(event);

--- a/src/app-web/modules/class-vprop-dragdrop.js
+++ b/src/app-web/modules/class-vprop-dragdrop.js
@@ -101,7 +101,8 @@ const AddDragDropHandlers = vprop => {
   if (!vprop.gRoot.root()) throw Error('arg1 must be a VProp');
   /* add storage */
   if (!vprop._extend) vprop._extend = {};
-  if (vprop._extend.dragdrop) throw Error(`vprop ${vprop.Id()} already has been extended`);
+  if (vprop._extend.dragdrop)
+    throw Error(`vprop ${vprop.Id()} already has been extended`);
   vprop._extend.dragdrop = {
     startPt: { x: 0, y: 0 },
     movePt: { x: 0, y: 0 },
@@ -117,12 +118,12 @@ const AddDragDropHandlers = vprop => {
   // This is necessary for the click handlers to register.  Otherwise
   // clicks are missed.
   vprop.visBG.mouseenter(event => {
-    if (DBG) console.log('mouseenter')
+    if (DBG) console.log('mouseenter');
     event.stopPropagation();
     DATA.VM_PropMouseEnter(vprop);
   });
   vprop.gRoot.mouseleave(event => {
-    if (DBG) console.log('mouseleave')
+    if (DBG) console.log('mouseleave');
     event.stopPropagation();
     DATA.VM_PropMouseExit(vprop);
   });
@@ -133,7 +134,7 @@ const AddDragDropHandlers = vprop => {
   // handle start of drag
   vprop.gRoot.on('dragstart.propmove', event => {
     event.stopPropagation();
-    if (DBG) console.log('dragstart')
+    if (DBG) console.log('dragstart');
     vprop.gRoot.attr('pointer-events', 'none');
     // REVIEW: mouse leave should not be necessary during drag?
     // DATA.VM_PropMouseExit(vprop);
@@ -147,7 +148,7 @@ const AddDragDropHandlers = vprop => {
 
   // handle drag while moving
   vprop.gRoot.on('dragmove.propmove', event => {
-    if (DBG) console.log('dragmove')
+    if (DBG) console.log('dragmove');
     // do not stopPropagation because mouse events need to update drop targets
     SaveEventCoordsToBox(event, vprop._extend.dragdrop.movePt);
     // this is necessary to update vmech during a drag
@@ -159,7 +160,7 @@ const AddDragDropHandlers = vprop => {
     event.detail.event.preventDefault();
     event.detail.event.stopPropagation();
 
-    if (DBG) console.log('dragend')
+    if (DBG) console.log('dragend');
     vprop.gRoot.attr('pointer-events', 'all');
     SaveEventCoordsToBox(event, vprop._extend.dragdrop.endPt);
     if (vprop.DragEnd) vprop.DragEnd(event);
@@ -227,7 +228,10 @@ const AddDragDropHandlers = vprop => {
       vprop.ToRoot();
       DATA.VM_ClearVPropPosition(vprop);
       if (DBG) console.log(`[${vpropId}] moved to [${dropId}]`);
-      UTILS.RLog('PropertyDrag', `Drag property id=${vprop.id} onto id=${dropId} at ${dropXY}`);
+      UTILS.RLog(
+        'PropertyDrag',
+        `Drag property id=${vprop.id} onto id=${dropId} at ${dropXY}`
+      );
     } else {
       // dropped on the desktop, no parent
       vprop.ToRoot();
@@ -237,7 +241,10 @@ const AddDragDropHandlers = vprop => {
         vprop.LayoutDisabled(true);
         const { x, y } = DragState(vprop).gRootXY;
         vprop.Move(x + dx, y + dy);
-        UTILS.RLog('PropertyDrag', `Drag property id=${vprop.id} from id=${parent} to ${dropXY}`);
+        UTILS.RLog(
+          'PropertyDrag',
+          `Drag property id=${vprop.id} from id=${parent} to ${dropXY}`
+        );
       } else {
         if (DBG) console.log(`[${vpropId}] moved on desktop`);
         vprop.LayoutDisabled(true);

--- a/src/app-web/modules/class-vprop-dragdrop.js
+++ b/src/app-web/modules/class-vprop-dragdrop.js
@@ -229,6 +229,19 @@ const AddDragDropHandlers = vprop => {
     if (DATA.IsViewOnly()) return;
 
     // it did move, so do drop target magic
+    // Before reading the drop target, purge the dragged vprop and ALL of its
+    // descendants from the rollover map. When a parent is dragged, its children
+    // and grandchildren may have received mouseenter events before pointer-events:none
+    // took effect, leaving stale entries that .pop() would misidentify as the drop target.
+    const collectDescendants = (propId, acc) => {
+      acc.push(propId);
+      (DATA.Children(propId) || []).forEach(childId =>
+        collectDescendants(childId, acc)
+      );
+      return acc;
+    };
+    DATA.VM_ClearRolloverForVPropIds(collectDescendants(vpropId, []));
+
     const dropId = DATA.VM_PropsMouseOver().pop();
     const dropXY = `(${DragState(vprop).gRootXY.x}, ${DragState(vprop).gRootXY.y})`;
 

--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -931,7 +931,7 @@ PMCData.PMC_PropUpdate = (propId, newData) => {
   const prop = m_graph.node(numericId);
   // make a copy of the prop with overwritten new data
   // local data will be updated on DBSYNC event, so don't write it here
-  const propData = Object.assign(prop, newData, { id: numericId }); // id last to make sure we're using a cleaned one
+  const propData = Object.assign({}, prop, newData, { id: numericId }); // id last to make sure we're using a cleaned one
   propData.propType = propData.propType || DATAMAP.PMC_MODELTYPES.COMPONENT.id; // default to component
   const pmcDataId = ASET.selectedPMCDataId;
   UTILS.RLog(
@@ -1022,8 +1022,7 @@ PMCData.PMC_SetPropParent = (nodeId, parentId) => {
     return false;
   }
   const id = Number(nodeId);
-  const pid =
-    parentId !== undefined && parentId !== null ? Number(parentId) : undefined;
+  const pid = parentId !== undefined && parentId !== null ? Number(parentId) : null;
 
   // Check for circular reference
   if (pid !== undefined && m_IsRecursive(m_graph, id, pid)) {

--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -126,6 +126,22 @@ PMCData.ClearModel = () => {
  * This should be only be called by ADMData.InitializeModel().
  * NEVER CALL THIS FUNCTION DIRECTLY
  */
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/**
+ *  Check if setting parentId as parent of nodeId would create a cycle.
+ *  Returns true if nodeId is an ancestor of parentId in the designated graph.
+ */
+function m_IsRecursive(graph, nodeId, parentId) {
+  if (parentId === undefined || parentId === null) return false;
+  const id = Number(nodeId);
+  let curr = parentId;
+  while (curr !== undefined && curr !== null) {
+    if (Number(curr) === id) return true;
+    curr = graph.parent(curr);
+  }
+  return false;
+}
+
 PMCData.InitializeModel = (model, admdb, resources) => {
   const g = new Graph({ directed: true, compound: true, multigraph: true });
   if (!admdb)
@@ -174,12 +190,18 @@ PMCData.InitializeModel = (model, admdb, resources) => {
             description: obj.description
           });
           if (obj.parent) {
-            try {
-              g.setParent(obj.id, obj.parent);
-            } catch (e) {
-              console.error(
-                `InitializeModel: Error setting parent ${obj.parent} for ${obj.id}: ${e.message}`
-              );
+            if (m_IsRecursive(g, obj.id, obj.parent)) {
+              const msg = `Cycle detected: removing parent ${obj.parent} for prop ${obj.id}`;
+              console.warn(`InitializeModel: ${msg}`);
+              UTILS.RLog('ERROR', `InitializeModel: ${msg}`);
+            } else {
+              try {
+                g.setParent(obj.id, obj.parent);
+              } catch (e) {
+                console.error(
+                  `InitializeModel: Error setting parent ${obj.parent} for ${obj.id}: ${e.message}`
+                );
+              }
             }
           }
           break;
@@ -573,6 +595,11 @@ function f_NodeSetParent(nodeId, parent) {
   let value = parent;
   if (value === null) value = undefined;
   if (typeof value === 'string') value = Number(value);
+  if (m_IsRecursive(m_graph, nodeId, value)) {
+    const msg = `Cycle detected: removing parent ${value} for prop ${nodeId}`;
+    console.warn(`f_NodeSetParent: ${msg}`);
+    return;
+  }
   try {
     m_graph.setParent(nodeId, value);
   } catch (e) {
@@ -999,18 +1026,11 @@ PMCData.PMC_SetPropParent = (nodeId, parentId) => {
     parentId !== undefined && parentId !== null ? Number(parentId) : undefined;
 
   // Check for circular reference
-  if (pid !== undefined) {
-    const ancestors = [];
-    let curr = pid;
-    while (curr !== undefined) {
-      if (curr === id) {
-        console.error(
-          `PMC_SetPropParent: Circular reference detected! Cannot set ${id} as child of ${pid}`
-        );
-        return false;
-      }
-      curr = PMCData.PropParent(curr);
-    }
+  if (pid !== undefined && m_IsRecursive(m_graph, id, pid)) {
+    console.error(
+      `PMC_SetPropParent: Circular reference detected! Cannot set ${id} as child of ${pid}`
+    );
+    return false;
   }
 
   UTILS.RLog('PropertySetParent', `id: ${id} parentId: ${pid}`);

--- a/src/app-web/modules/pmc-data.js
+++ b/src/app-web/modules/pmc-data.js
@@ -174,7 +174,13 @@ PMCData.InitializeModel = (model, admdb, resources) => {
             description: obj.description
           });
           if (obj.parent) {
-            g.setParent(obj.id, obj.parent);
+            try {
+              g.setParent(obj.id, obj.parent);
+            } catch (e) {
+              console.error(
+                `InitializeModel: Error setting parent ${obj.parent} for ${obj.id}: ${e.message}`
+              );
+            }
           }
           break;
         case 'mech':
@@ -249,7 +255,7 @@ PMCData.InitializeModel = (model, admdb, resources) => {
       const vprop = VM.VM_VProp(id);
       // only position components, not props
       // because visuals array doesn't remove stuff
-      if (PMCData.PropParent()) {
+      if (PMCData.PropParent(id)) {
         if (DBG) console.warn(`vprop ${id} has a parent: skipping`);
         return;
       }
@@ -567,7 +573,13 @@ function f_NodeSetParent(nodeId, parent) {
   let value = parent;
   if (value === null) value = undefined;
   if (typeof value === 'string') value = Number(value);
-  m_graph.setParent(nodeId, value);
+  try {
+    m_graph.setParent(nodeId, value);
+  } catch (e) {
+    console.error(
+      `f_NodeSetParent: Error setting parent ${value} for ${nodeId}: ${e.message}`
+    );
+  }
 }
 
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -971,20 +983,36 @@ PMCData.PMC_PropDelete = propId => {
  *  different than newParentId
  */
 PMCData.PMC_IsDifferentPropParent = (propId, newParentId) => {
-  return PMCData.PropParent(propId) !== newParentId;
+  const pid = propId !== undefined ? Number(propId) : undefined;
+  const npid = newParentId !== undefined ? Number(newParentId) : undefined;
+  return PMCData.PropParent(pid) !== npid;
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 PMCData.PMC_SetPropParent = (nodeId, parentId) => {
   // NOTE: a parentId of value of 'undefined' because that's how
   // graphlib removes a parent from a node
   if (!PMCData.PMC_IsDifferentPropParent(nodeId, parentId)) {
-    // only write to the database (and roundtrip) if the propparent
-    // is different from last time
     return false;
   }
-  // REVIEW/FIXME: Is this coercion necessary once we convert to ints?
   const id = Number(nodeId);
-  const pid = Number(parentId);
+  const pid =
+    parentId !== undefined && parentId !== null ? Number(parentId) : undefined;
+
+  // Check for circular reference
+  if (pid !== undefined) {
+    const ancestors = [];
+    let curr = pid;
+    while (curr !== undefined) {
+      if (curr === id) {
+        console.error(
+          `PMC_SetPropParent: Circular reference detected! Cannot set ${id} as child of ${pid}`
+        );
+        return false;
+      }
+      curr = PMCData.PropParent(curr);
+    }
+  }
+
   UTILS.RLog('PropertySetParent', `id: ${id} parentId: ${pid}`);
   return PMCData.PMC_PropUpdate(id, { parent: pid }).then(rdata => {
     if (DBG) console.log('PropUpdate', JSON.stringify(rdata['pmcData.entities']));

--- a/src/app-web/modules/vm-data.js
+++ b/src/app-web/modules/vm-data.js
@@ -412,7 +412,9 @@ VM.VM_DeselectAllMechs = () => {
  *  broad.
  */
 VM.VM_DeselectAll = () => {
-  console.warn(`VM_DeselectAll() is deprecated. Use more specific selection manager calls.`);
+  console.warn(
+    `VM_DeselectAll() is deprecated. Use more specific selection manager calls.`
+  );
   DeselectAllProps();
   DeselectAllMechs();
   UR.Publish('SELECTION_CHANGED');

--- a/src/app-web/modules/vm-data.js
+++ b/src/app-web/modules/vm-data.js
@@ -286,6 +286,16 @@ VM.VM_PropsMouseOver = () => {
   return [...map_rollover.keys()];
 };
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+/** API.UI:
+ *  Remove the given prop IDs from the rollover tracking map.
+ *  Called before reading the drop target so that the dragged vprop and its
+ *  nested descendants are not mistakenly identified as drop targets.
+ *  @param {string[]} propIds - array of prop ID strings to remove
+ */
+VM.VM_ClearRolloverForVPropIds = propIds => {
+  propIds.forEach(id => map_rollover.delete(id));
+};
+/// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 /** API.VIEWMODEL:
  *  Set the maximum number of objects the user can select.
  *  After the limit is reached, users can not select any additional objects

--- a/src/system/comment-mgr/ac-comment.ts
+++ b/src/system/comment-mgr/ac-comment.ts
@@ -86,7 +86,7 @@ import DCCOMMENTS, {
   TCommentQueueActions
 } from './dc-comment.ts';
 
-const DBG = true;
+const DBG = false;
 const PR = 'ac-comments';
 
 /// TYPE DEFINITIONS //////////////////////////////////////////////////////////

--- a/src/system/comment-mgr/comment-mgr.js
+++ b/src/system/comment-mgr/comment-mgr.js
@@ -60,7 +60,7 @@ const { CREF_PREFIX } = DEFAULTS;
 
 /// CONSTANTS & DECLARATIONS //////////////////////////////////////////////////
 /// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-const DBG = true;
+const DBG = false;
 const PR = 'comment-mgr: ';
 
 const CMTBTNOFFSET = 10;


### PR DESCRIPTION
WIP

## The Problem

Under some conditions when dragging entities onto other entities to set parents, the system inadvertently ends up with a circular reference.

We can't consistently replicate it, so we're still trying to figure out the exact conditions where this happens.

This might be related dragging to a parent, then to the desktop (de-parent the entity), or perhaps back again.

e.g. in this model (from https://ru.modelingandevidence.app/ Period 3 group "Tiger" model ""it corrupted"")
- Note how "grass" (id: 316) has a parent 319 "sheep eating"...
- ...but "sheep eating" (id: 319) has a parent 316...
- ...creating a circular reference.
```json
"entities": [
    {
        "id": 316,
        "name": "grass",
        "propType": "cmp",
        "description": "",
        "type": "prop",
        "parent": 319
    },
    ...
    {
        "id": 319,
        "name": "sheep eating",
        "propType": "cmp",
        "description": "",
        "type": "prop",
        "parent": 316
    },
]
```

### Possible Circular Cause

<img width="376" height="239" alt="screenshot_567" src="https://github.com/user-attachments/assets/f7edc5ad-5a86-4513-a853-e8dd16f5b73e" />

This isn't 100% certain, but the culprit might be if you drag a group (B > C) away from the parent (A), what fires is a drag B onto C.  Because the drag module is managing drag for all the objects in the group it incorrectly thinks the drop is onto C, creating a circular reference.

Another case: 
1. Start with a group of 3 (A > B > C)
2. Drag (B > C) to desktop
3. Drag (B > C) back to A
4. Drag (A > B > C) to desktop => circular.


## Symptoms

The browser locks up with no error messages.  Telltale signs:
- The app bar is Gray (as if viewing someone else's model with no write access)
- The graph is not responsive (no hover)
- No console messages

### Why we are using null for parent updates
In our system, unsetting a parent relationship (e.g., dragging a node to the desktop) requires an explicit update to the database. While our internal graph (graphlib) uses undefined to represent "no parent," this value does not survive the transition to the server.

The issue is with JSON serialization: JSON.stringify() silently removes any keys with the value undefined. If we send an update object like { parent: undefined }, the server receives an empty object {} and assumes no change was requested for the parent field. As a result, the node "pops back" to its old parent on the next data sync.

By using null, we ensure the parent property is preserved in the JSON payload ({"parent": null}). Our sync logic already handles the conversion of this null back to undefined for local graph operations, ensuring consistency across the stack.


## The Fixes

This hotfix addresses five things:

1. Parents are properly set and removed when dragging and dropping.  
2. Explicitly check for circular references when updating the data after a drag and drop to prevent future circular references.
3. Remove the first offending node if there is a circular reference.  This should at least allow the model to load rather than simply locking up.
4. Fixes SVG-related bug where vmech comment buttons and labels had positioning problems when dragging.
5. Prevents the creation of a circular reference in the first place by clearing the rollover queue

Generally the circular parent seems to be added to the first entity.  But I'm sure this depends on how the students are using the system. So it's not perfect, but I figure better to leave something in place rather than removing the relationship altogether.

> 4

The SVG issue is caused by the SVG.js .move(x, y) method when applied to SVG <group> elements. The .move() method calculates the necessary translation by measuring the group's current bounding box (bbox()).  However, during a drag (when the badge loses hover and becomes hidden) or during reparenting (when the badge is quickly recreated before the DOM fully renders), the bbox() returns a height of 0. The .move(0, -7) method then calculates a translation assuming the height is zero. When the user later hovers over it and the group becomes visible (or when reparenting completes), the group actually has a height, meaning the previously calculated translation is now vertically incorrect by the height of the group!

> 5

When dragging a parent vprop that contains nested children, SVG.js fires
mouseenter for every prop under the cursor (parent, child, grandchild)
before pointer-events:none takes effect on the dragged element. This left
stale child/grandchild IDs in map_rollover, causing VM_PropsMouseOver().pop()
to return an inner descendant as the drop target instead of an external prop,
which produced circular parent references in 3+ generation hierarchies.

Added VM_ClearRolloverForVPropIds(propIds) to vm-data.js, which removes a
given list of IDs from map_rollover. Called in class-vprop-dragdrop.js dragend
immediately before reading the drop target, after recursively collecting the
dragged vprop's ID and all its descendants. This ensures only external props
remain in the rollover queue when the drop target is selected.


### Restoring explicit null for parent updates
Description This change ensures that unsetting a node's parent (dragging it to the desktop) is correctly persisted in the database.

- Forced Explicit Null: Updated `PMC_SetPropParent`
 to use null instead of undefined for the unparented state. This prevents JSON.stringify from stripping the parent field during network transmission, ensuring the server receives the update.

- Sync Compatibility: Confirmed that `f_NodeSetParent`
 correctly maps incoming null values from the server back to undefined for local graphlib compatibility.

- Fixed Partial Update Mutation: Refactored `PMC_PropUpdate`
 to use Object.assign({}, ...) to avoid mutating local graph nodes before server confirmation. This prevents inconsistent UI states if a network update fails or is delayed.


## To Test

Easy test is to load the `meme.loki` file from the droplet.
1. `git checkout hotfix/circular-parent`
2. Download and unzip the `tiger.zip`
[tiger.zip](https://github.com/user-attachments/files/25822059/tiger.zip)
3. Copy the `tiger/meme.loki` file into `meme-2023/data/db`
9. Copy the `tiger/units/deer` folder into `meme-2023/units`
10. `npm run start`
11. Log in as `tiger1-z2se`
12. Open the dev console.
13. Open the "more curruption" model.
14. You should see a message: Cycle detected: removing parent...
<img width="518" height="34" alt="screenshot_566" src="https://github.com/user-attachments/assets/43e22851-4f44-4db7-8482-b7751819647a" />
15. ..but the model should open.
16. The "NOT Untitled' project should successfully load too

> ![WARNING]
> This is NOT ready to be deployed to the droplet!!!
> A LOT of testing should be done first.
> One possible workaround is to ask the tiger group to just start over as a fallback.

Addresses #160
